### PR TITLE
feat(table): adds table-level settings script

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@ $ psql_lob_prod -f sql/cache_hit_rate.sql
 #### [`index_size.sql`](sql/index_size.sql) (read permission)
 * **Returns the size of each index in bytes**
 
+#### [`table_settings.sql`](sql/table_settings.sql) (read permission)
+* **Returns the table-specific settings of each table.**
+
 #### [`table_size.sql`](sql/table_size.sql) (read permission)
 * **Returns the size of each table in bytes**
 * Does not include size of the tables' indices

--- a/sql/table_settings.sql
+++ b/sql/table_settings.sql
@@ -1,0 +1,4 @@
+SELECT relname, unnest(reloptions)
+FROM PG_CLASS
+JOIN pg_namespace ON pg_namespace.oid = pg_class.relnamespace
+WHERE pg_namespace.nspname = 'public' AND reloptions IS NOT NULL;

--- a/sql/vacuum_stats.sql
+++ b/sql/vacuum_stats.sql
@@ -35,4 +35,4 @@ SELECT
 FROM
   pg_stat_user_tables psut INNER JOIN pg_class ON psut.relid = pg_class.oid
     INNER JOIN vacuum_settings ON pg_class.oid = vacuum_settings.oid
-ORDER BY 1
+ORDER BY psut.n_dead_tup DESC;


### PR DESCRIPTION
1. Orders vacuum stats by the most dead tuples first.
2. Adds table-level settings script for viewing the setting on a table.

Example output:

```
$ psql_lob_api -f sql/table_settings.sql
Expanded display is used automatically.
     relname     |                unnest
-----------------+--------------------------------------
 accounts_keys   | autovacuum_vacuum_scale_factor=0.0
 accounts_keys   | autovacuum_vacuum_threshold=10000
 accounts_keys   | autovacuum_analyze_scale_factor=0.01
 accounts_keys   | autovacuum_analyze_threshold=0
 checks          | autovacuum_vacuum_scale_factor=0
 checks          | autovacuum_vacuum_threshold=10000
 checks          | autovacuum_analyze_scale_factor=0.01
 checks          | autovacuum_analyze_threshold=0
 postcards       | autovacuum_vacuum_scale_factor=0
 postcards       | autovacuum_vacuum_threshold=10000
 postcards       | autovacuum_analyze_scale_factor=0.01
 postcards       | autovacuum_analyze_threshold=0
 verifications   | autovacuum_vacuum_scale_factor=0
 verifications   | autovacuum_vacuum_threshold=10000
 verifications   | autovacuum_analyze_scale_factor=0.01
 verifications   | autovacuum_analyze_threshold=0
 letters         | autovacuum_vacuum_scale_factor=0
 letters         | autovacuum_vacuum_threshold=10000
 letters         | autovacuum_analyze_scale_factor=0.01
 letters         | autovacuum_analyze_threshold=0
 sam_areas       | autovacuum_vacuum_scale_factor=0
 sam_areas       | autovacuum_vacuum_threshold=10000
 sam_areas       | autovacuum_analyze_scale_factor=0.01
 sam_areas       | autovacuum_analyze_threshold=0
 trackings       | autovacuum_vacuum_scale_factor=0
 trackings       | autovacuum_vacuum_threshold=10000
 trackings       | autovacuum_analyze_scale_factor=0.01
 trackings       | autovacuum_analyze_threshold=0
 statements      | autovacuum_vacuum_scale_factor=0
 statements      | autovacuum_vacuum_threshold=10000
 statements      | autovacuum_analyze_scale_factor=0.01
 statements      | autovacuum_analyze_threshold=0
 addresses       | autovacuum_vacuum_scale_factor=0
 addresses       | autovacuum_vacuum_threshold=10000
 addresses       | autovacuum_analyze_scale_factor=0.01
 addresses       | autovacuum_analyze_threshold=0
 accounts        | autovacuum_vacuum_scale_factor=0.0
 accounts        | autovacuum_vacuum_threshold=10000
 accounts        | autovacuum_analyze_scale_factor=0.01
 accounts        | autovacuum_analyze_threshold=0
 sam_routes      | autovacuum_vacuum_scale_factor=0
 sam_routes      | autovacuum_vacuum_threshold=10000
 sam_routes      | autovacuum_analyze_scale_factor=0.01
 sam_routes      | autovacuum_analyze_threshold=0
 tracking_events | autovacuum_vacuum_scale_factor=0
 tracking_events | autovacuum_vacuum_threshold=10000
 tracking_events | autovacuum_analyze_scale_factor=0.01
 tracking_events | autovacuum_analyze_threshold=0
(48 rows)
```