### PR TITLE
Order table_size_with_indices.sql results by total relation size

### DIFF
--- a/sql/table_size_with_indices.sql
+++ b/sql/table_size_with_indices.sql
@@ -5,4 +5,4 @@ LEFT JOIN pg_namespace n ON (n.oid = c.relnamespace)
 WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
   AND n.nspname !~ '^pg_toast'
   AND c.relkind='r'
-ORDER BY pg_table_size(c.oid) DESC;
+ORDER BY pg_total_relation_size(c.oid) DESC;


### PR DESCRIPTION
The order of results is currently incorrect because it is ordered by just the table size, not the table and indices.